### PR TITLE
test

### DIFF
--- a/lib/ransack/adapters/active_record/ransack/nodes/condition.rb
+++ b/lib/ransack/adapters/active_record/ransack/nodes/condition.rb
@@ -7,9 +7,14 @@ module Ransack
           association = attribute.parent
           if negative? && attribute.associated_collection?
             query = context.build_correlated_subquery(association)
-            query.where(format_predicate(attribute).not)
             context.remove_association(association)
-            Arel::Nodes::NotIn.new(context.primary_key, Arel.sql(query.to_sql))
+            if self.predicate_name == 'not_null' && self.value
+              query.where(format_predicate(attribute))
+              Arel::Nodes::In.new(context.primary_key, Arel.sql(query.to_sql))
+            else
+              query.where(format_predicate(attribute).not)
+              Arel::Nodes::NotIn.new(context.primary_key, Arel.sql(query.to_sql))
+            end
           else
             format_predicate(attribute)
           end

--- a/spec/ransack/predicate_spec.rb
+++ b/spec/ransack/predicate_spec.rb
@@ -329,6 +329,28 @@ module Ransack
         field = "#{quote_table_name("people")}.#{quote_column_name("name")}"
         expect(@s.result.to_sql).to match /#{field} IS NULL/
       end
+
+      describe 'with association qeury' do
+        it 'generates a value IS NOT NULL query' do
+          @s.comments_id_not_null = true
+          sql = @s.result.to_sql
+          parent_field = "#{quote_table_name("people")}.#{quote_column_name("id")}"
+          expect(sql).to match /#{parent_field} IN/
+          field = "#{quote_table_name("comments")}.#{quote_column_name("id")}"
+          expect(sql).to match /#{field} IS NOT NULL/
+          expect(sql).not_to match /AND NOT/
+        end
+
+        it 'generates a value IS NULL query when assigned false' do
+          @s.comments_id_not_null = false
+          sql = @s.result.to_sql
+          parent_field = "#{quote_table_name("people")}.#{quote_column_name("id")}"
+          expect(sql).to match /#{parent_field} NOT IN/
+          field = "#{quote_table_name("comments")}.#{quote_column_name("id")}"
+          expect(sql).to match /#{field} IS NULL/
+          expect(sql).to match /AND NOT/
+        end
+      end
     end
 
     describe 'present' do


### PR DESCRIPTION
## Demo

### Create example data In `rake console`

```
> Article.count
=> 31
> ids = Article.all.pluck(:id).sample(4)
=> [12, 28, 5, 22]
> Comment.where(article_id: ids).destroy_all
```

### _null query is fine

```
> Article.ransack('comments_id_null' => '1').result(distinct: true).count
=> 4 # OK
> Article.ransack('comments_id_null' => '0').result(distinct: true).count
=> 27 # OK 
```

### not_null query with true value is wrong response 

```
> Article.ransack('comments_id_not_null' => '1').result(distinct: true).count
=> 31 # BAD
> Article.ransack('comments_id_not_null' => '0').result(distinct: true).count
=> 4 # OK
```

### In SQL

```
> puts Article.ransack('comments_id_not_null' => '1').result(distinct: true).to_sql
```

```
SELECT DISTINCT "articles".* 
FROM "articles" 
WHERE ('default_scope' = 'default_scope') 
AND ("articles"."id" NOT IN (
  SELECT "comments"."article_id" 
  FROM "comments" 
  WHERE "comments"."article_id" = "articles"."id" 
  AND NOT ("comments"."id" IS NOT NULL)))
```

It should be

```
SELECT DISTINCT "articles".* 
FROM "articles" 
WHERE ('default_scope' = 'default_scope') 
AND ("articles"."id" IN (
  SELECT "comments"."article_id" 
  FROM "comments" 
  WHERE "comments"."article_id" = "articles"."id" 
  AND ("comments"."id" IS NOT NULL)))
```

